### PR TITLE
build w/o es6 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-map-props",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "To help with props mapping when using apollo with React",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "build/index.js",
   "module": "build/index.js",
   "scripts": {
-    "build": "npm run babelify:esmodules",
-    "babelify:esmodules": "BABEL_ENV=esmodules babel src --out-dir build"
+    "build": "npm run babelify:modules",
+    "babelify:modules": "BABEL_ENV=modules babel src --out-dir build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
create-react-app(CRA) does not allow config on jest easily, so node_modules using es6 syntax will cause jest to error out with ` SyntaxError: Unexpected token export`;
Thinking if we should just build it differently so it could be consumed by jest in CRA apps. 