### PR TITLE
allow config for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ We created three Higher Order Component (HOC) that wraps the Apollo [Query](http
 install this package by running `npm install apollo-map-props --save`
 
 ## Configuration
-add below code to `index.js` for setting withQuery default fetchPolicy or other configs
+The default fetchPolicy for withQuery is `cache-and-network`.
+Add below code to `index.js` for changing default fetchPolicy or adding other configs.
+
 ```javascript
 import { withQuery } from 'apollo-map-props';
-withQuery.setConfig({ fetchPolicy: 'cache-and-network' })
+withQuery.setConfig({ fetchPolicy: 'network-only' })
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ We created three Higher Order Component (HOC) that wraps the Apollo [Query](http
 ## Installation
 install this package by running `npm install apollo-map-props --save`
 
+## Configuration
+add below code to `index.js` for setting withQuery default fetchPolicy or other configs
+```javascript
+import { withQuery } from 'apollo-map-props';
+withQuery.setConfig({ fetchPolicy: 'cache-and-network' })
+```
+
 ## Usage
 
 ### withQuery

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-map-props",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "To help with props mapping when using apollo with React",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/withQuery.js
+++ b/src/withQuery.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Query } from 'react-apollo';
 import get from './get';
 
-const DEFAULT_FETCH_POLICY = 'cache-and-network';
+let config = { fetchPolicy: 'cache-and-network' };
 
 function getDisplayName(mapProps) {
   const props = mapProps({});
@@ -14,7 +14,7 @@ export default function withQuery(mapProps, mapResultToProps) {
 
   return WrappedComponent => {
     const component = props => (
-      <Query fetchPolicy={DEFAULT_FETCH_POLICY} {...mapProps(props)}>
+      <Query fetchPolicy={config.fetchPolicy} {...mapProps(props)}>
         {result => {
           const mappedProps = mapResultToProps(result, props);
           return <WrappedComponent {...props} {...mappedProps} />;
@@ -25,4 +25,8 @@ export default function withQuery(mapProps, mapResultToProps) {
     component.displayName = `withQuery(${displayName})`;
     return React.memo(component);
   };
+}
+
+withQuery.setConfig = newConfig => {
+  config = { ...config, ...newConfig };
 }


### PR DESCRIPTION
Allow client to set configuration for default fetch policy.

How to test:
run `npm run build` in this repo
copy and paste this repo's `build/withQuery.js` to client repo's `node_modules/apollo-map-props/build/withQuery.js`
In client repo's `index.js`, add `withQuery.setConfig({ fetchPolicy: 'cache-only' })` 
Nothing will fetch upon refreshing
change code to `withQuery.setConfig({ fetchPolicy: 'network-only' })`
Things will start fetching agian