### PR TITLE
IDP Checks: Rename jobs.ci -> jobs.setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  ci:
+  setup:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Internal IDP check requires that this job be called `setup` for the evaluation to succeed